### PR TITLE
Rename website heading to Claude Test

### DIFF
--- a/src/components/AppNavbar/AppNavbar.test.tsx
+++ b/src/components/AppNavbar/AppNavbar.test.tsx
@@ -20,7 +20,7 @@ describe('AppNavbar', () => {
 
   it('renders the site name', () => {
     render(<Navbar togglePopup={togglePopup} toggleSlideOut={toggleSlideOut} />);
-    expect(screen.getByText('Chris Royall')).toBeInTheDocument();
+    expect(screen.getByText('Claude Test')).toBeInTheDocument();
   });
 
   it('renders the Contact button', () => {

--- a/src/components/AppNavbar/AppNavbar.tsx
+++ b/src/components/AppNavbar/AppNavbar.tsx
@@ -23,7 +23,7 @@ const Navbar: React.FC<NavbarProps> = ({ togglePopup, toggleSlideOut }) => {
   
       {/* Website Name */}
       <div className="navbar-brand" onClick={() => handleLinkClick('Privacy Policy')}>
-        Chris Royall
+        Claude Test
       </div>
   
       {/* Hamburger Button */}


### PR DESCRIPTION
Renames the navbar brand heading from "Chris Royall" to "Claude Test". Also updates the corresponding test assertion.